### PR TITLE
fix(@aws-amplify/datastore): Fix predicate group types

### DIFF
--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -376,6 +376,7 @@ describe('Predicates', () => {
 					]);
 				});
 
+
 				describe('with a logical grouping', () => {
 					test('can perform and() logic, matching an item', async () => {
 						const query = recursivePredicateFor(AuthorMeta).and(a => [
@@ -390,6 +391,21 @@ describe('Predicates', () => {
 						expect(matches[0].name).toBe('Bob Jones');
 					});
 
+					test('can perform and() logic, matching an item - NEGATED', async () => {
+						const query = recursivePredicateFor(AuthorMeta).not(negated =>
+							negated.and(a => [
+								a.name.contains('Bob'),
+								a.name.contains('Jones'),
+							])
+						);
+						const matches = await mechanism.execute<ModelOf<typeof Author>>(
+							query
+						);
+
+						expect(matches.length).toBe(4);
+						expect(matches.map(n => n.name)).not.toContain('Bob Jones');
+					});
+
 					test('can perform and() logic, matching no items', async () => {
 						const query = recursivePredicateFor(AuthorMeta).and(a => [
 							a.name.contains('Adam'),
@@ -400,6 +416,20 @@ describe('Predicates', () => {
 						);
 
 						expect(matches.length).toBe(0);
+					});
+
+					test('can perform and() logic, matching no items - NEGATED', async () => {
+						const query = recursivePredicateFor(AuthorMeta).not(negated =>
+							negated.and(a => [
+								a.name.contains('Adam'),
+								a.name.contains('Donut'),
+							])
+						);
+						const matches = await mechanism.execute<ModelOf<typeof Author>>(
+							query
+						);
+
+						expect(matches.length).toBe(5);
 					});
 
 					test('can perform or() logic, matching different items', async () => {
@@ -418,6 +448,22 @@ describe('Predicates', () => {
 						]);
 					});
 
+					test('can perform or() logic, matching different items - NEGATED', async () => {
+						const query = recursivePredicateFor(AuthorMeta).not(negated =>
+							negated.or(a => [
+								a.name.contains('Bob'),
+								a.name.contains('Donut'),
+							])
+						);
+						const matches = await mechanism.execute<ModelOf<typeof Author>>(
+							query
+						);
+
+						expect(matches.length).toBe(3);
+						expect(matches.map(m => m.name)).not.toContain('Bob Jones');
+						expect(matches.map(m => m.name)).not.toContain('Debbie Donut');
+					});
+
 					test('can perform or() logic, matching a single item', async () => {
 						const query = recursivePredicateFor(AuthorMeta).or(a => [
 							a.name.contains('Bob'),
@@ -429,6 +475,21 @@ describe('Predicates', () => {
 
 						expect(matches.length).toBe(1);
 						expect(matches[0].name).toEqual('Bob Jones');
+					});
+
+					test('can perform or() logic, matching a single item - NEGATED', async () => {
+						const query = recursivePredicateFor(AuthorMeta).not(negated =>
+							negated.or(a => [
+								a.name.contains('Bob'),
+								a.name.contains('Jones'),
+							])
+						);
+						const matches = await mechanism.execute<ModelOf<typeof Author>>(
+							query
+						);
+
+						expect(matches.length).toBe(4);
+						expect(matches.map(n => n.name)).not.toContain('Bob Jones');
 					});
 
 					test('can perform or() logic, matching a single item with extra unmatched conditions', async () => {
@@ -492,6 +553,27 @@ describe('Predicates', () => {
 
 						expect(matches.length).toBe(1);
 						expect(matches.map(m => m.name)).toEqual(['Debbie Donut']);
+					});
+
+					test('can perform and() logic with nested or() logic - NEGATED', async () => {
+						const query = recursivePredicateFor(AuthorMeta).not(c =>
+							c.and(author_and => [
+								author_and.or(a => [
+									a.name.contains('Bob'),
+									a.name.contains('Donut'),
+								]),
+								author_and.or(a => [
+									a.name.contains('Debbie'),
+									a.name.contains('from the Legend of Zelda'),
+								]),
+							])
+						);
+						const matches = await mechanism.execute<ModelOf<typeof Author>>(
+							query
+						);
+
+						expect(matches.length).toBe(4);
+						expect(matches.map(m => m.name)).not.toContain('Debbie Donut');
 					});
 
 					test('can perform simple not() logic, matching all but one item', async () => {
@@ -719,6 +801,25 @@ describe('Predicates', () => {
 					expect(matches[0].name).toBe("Bob Jones's Blog");
 				});
 
+				test('can filter nested or() .. and() - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(c =>
+						c.or(b => [
+							b.owner.and(o => [
+								o.name.contains('Bob'),
+								o.name.contains('Jones'),
+							]),
+							b.owner.and(o => [
+								o.name.contains('Debbie'),
+								o.name.contains('Starling'),
+							]),
+						])
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(4);
+					expect(matches.map(m => m.name)).not.toContain("Bob Jones's Blog");
+				});
+
 				test('can filter 3 level nested, logically grouped', async () => {
 					const query = recursivePredicateFor(BlogMeta).or(b => [
 						b.owner.and(o => [o.name.contains('Bob'), o.name.contains('West')]),
@@ -736,6 +837,28 @@ describe('Predicates', () => {
 					expect(matches[0].name).toBe("Debbie Donut's Blog");
 				});
 
+				test('can filter 3 level nested, logically grouped - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(negated =>
+						negated.or(b => [
+							b.owner.and(o => [
+								o.name.contains('Bob'),
+								o.name.contains('West'),
+							]),
+							b.owner.and(owner => [
+								owner.blog.or(innerBlog => [
+									innerBlog.name.contains('Debbie'),
+									innerBlog.name.contains('from the Legend of Zelda'),
+								]),
+								owner.name.contains('Donut'),
+							]),
+						])
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(4);
+					expect(matches.map(n => n.name)).not.toContain("Debbie Donut's Blog");
+				});
+
 				test('can filter on child collections', async () => {
 					const query =
 						recursivePredicateFor(BlogMeta).posts.title.contains('Bob Jones');
@@ -743,6 +866,16 @@ describe('Predicates', () => {
 
 					expect(matches.length).toBe(1);
 					expect(matches[0].name).toBe("Bob Jones's Blog");
+				});
+
+				test('can filter on child collections - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(negated =>
+						negated.posts.title.contains('Bob Jones')
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(4);
+					expect(matches.map(n => n.name)).not.toContain("Bob Jones's Blog");
 				});
 
 				test('can filter on child collections in or()', async () => {
@@ -759,6 +892,22 @@ describe('Predicates', () => {
 					]);
 				});
 
+				test('can filter on child collections in or() - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(negated =>
+						negated.or(b => [
+							b.posts.title.contains('Bob Jones'),
+							b.posts.title.contains("Zelda's Blog post"),
+						])
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(3);
+					expect(matches.map(m => m.name)).not.toContain("Bob Jones's Blog");
+					expect(matches.map(m => m.name)).not.toContain(
+						"Zelda from the Legend of Zelda's Blog"
+					);
+				});
+
 				test('can filter on or() extended off child collections', async () => {
 					const query = recursivePredicateFor(BlogMeta).posts.or(p => [
 						p.title.contains('Bob Jones'),
@@ -773,6 +922,22 @@ describe('Predicates', () => {
 					]);
 				});
 
+				test('can filter on or() extended off child collections - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(negated =>
+						negated.posts.or(p => [
+							p.title.contains('Bob Jones'),
+							p.title.contains("Zelda's Blog post"),
+						])
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(3);
+					expect(matches.map(m => m.name)).not.toContain("Bob Jones's Blog");
+					expect(matches.map(m => m.name)).not.toContain(
+						"Zelda from the Legend of Zelda's Blog"
+					);
+				});
+
 				test('can filter and() between parent and child collection properties', async () => {
 					const query = recursivePredicateFor(BlogMeta).and(b => [
 						b.name.contains('Bob Jones'),
@@ -781,6 +946,18 @@ describe('Predicates', () => {
 					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
 
 					expect(matches.length).toBe(0);
+				});
+
+				test('can filter and() between parent and child collection properties - NEGATED', async () => {
+					const query = recursivePredicateFor(BlogMeta).not(negated =>
+						negated.and(b => [
+							b.name.contains('Bob Jones'),
+							b.posts.title.contains('Zelda'),
+						])
+					);
+					const matches = await mechanism.execute<ModelOf<typeof Blog>>(query);
+
+					expect(matches.length).toBe(5);
 				});
 			});
 		});

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -376,6 +376,33 @@ describe('Predicates', () => {
 					]);
 				});
 
+				describe('predicate typings', () => {
+					test('not group builders must return single child condition', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).not(a => [
+								a.name.contains('Bob'),
+							])
+						).toThrow(
+							"Invalid predicate. Terminate your predicate with a valid condition (e.g., `p => p.field.eq('value')`) or pass `Predicates.ALL`."
+						);
+					});
+
+					test('and group builders must return an array of child conditions', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `and` groups must return an array of child conditions.'
+						);
+					});
+
+					test('or group builders must return array of child conditions', async () => {
+						expect(() =>
+							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `or` groups must return an array of child conditions.'
+						);
+					});
+				});
 
 				describe('with a logical grouping', () => {
 					test('can perform and() logic, matching an item', async () => {

--- a/packages/datastore/__tests__/Predicate.ts
+++ b/packages/datastore/__tests__/Predicate.ts
@@ -377,8 +377,10 @@ describe('Predicates', () => {
 				});
 
 				describe('predicate typings', () => {
-					test('not group builders must return single child condition', async () => {
+					test('not group builders must return single child condition - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).not(a => [
 								a.name.contains('Bob'),
 							])
@@ -387,17 +389,51 @@ describe('Predicates', () => {
 						);
 					});
 
-					test('and group builders must return an array of child conditions', async () => {
+					test('and group builders must return an array of child conditions - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
 						).toThrow(
 							'Invalid predicate. `and` groups must return an array of child conditions.'
 						);
 					});
 
-					test('or group builders must return array of child conditions', async () => {
+					test('or group builders must return array of child conditions - recursive/relational predicates', async () => {
 						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
 							recursivePredicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `or` groups must return an array of child conditions.'
+						);
+					});
+
+					test('not group builders must return single child condition - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).not(a => [a.name.contains('Bob')])
+						).toThrow(
+							"Invalid predicate. Terminate your predicate with a valid condition (e.g., `p => p.field.eq('value')`) or pass `Predicates.ALL`."
+						);
+					});
+
+					test('and group builders must return an array of child conditions - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).and(a => a.name.contains('Bob'))
+						).toThrow(
+							'Invalid predicate. `and` groups must return an array of child conditions.'
+						);
+					});
+
+					test('or group builders must return array of child conditions - flat predicates', async () => {
+						expect(() =>
+							// @ts-expect-error doesn't work until TS 3.9 ... until then:
+							// @ts-ignore
+							predicateFor(AuthorMeta).or(a => a.name.contains('Bob'))
 						).toThrow(
 							'Invalid predicate. `or` groups must return an array of child conditions.'
 						);

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -578,7 +578,7 @@ export class GroupCondition {
 							applyConditionsToV1Predicate(
 								p,
 								individualRowJoinConditions,
-								negateChildren
+								false
 							);
 						relativesPredicates.push(predicate as any);
 					}

--- a/packages/datastore/src/predicates/next.ts
+++ b/packages/datastore/src/predicates/next.ts
@@ -814,6 +814,15 @@ export function recursivePredicateFor<T extends PersistentModel>(
 			// to head off mutability concerns.
 			const { query, newTail } = copyLink();
 
+			const childConditions = builder(
+				recursivePredicateFor(ModelType, allowRecursion)
+			);
+			if (!Array.isArray(childConditions)) {
+				throw new Error(
+					`Invalid predicate. \`${op}\` groups must return an array of child conditions.`
+				);
+			}
+
 			// the customer will supply a child predicate, which apply to the `model.field`
 			// of the tail GroupCondition.
 			newTail?.operands.push(
@@ -822,9 +831,7 @@ export function recursivePredicateFor<T extends PersistentModel>(
 					field,
 					undefined,
 					op as 'and' | 'or',
-					builder(recursivePredicateFor(ModelType, allowRecursion)).map(c =>
-						internals(c)
-					)
+					childConditions.map(c => internals(c))
 				)
 			);
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#pull-requests
-->

#### Description of changes
<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

Adds red squiggles and prevents TS builds if `and`/`or`/`not` predicate functions return invalid results. I.e., `and` and `or` predicates should return an array of "completed" child predicates. `not` should return a single, completed child predicate.

![image](https://user-images.githubusercontent.com/8375502/199868468-d34fe127-920b-4021-9bd4-6bf7cf0ae019.png)

![image](https://user-images.githubusercontent.com/8375502/199868578-89c8f25a-7aa9-4f83-81e6-8ec578d1cffc.png)

![image](https://user-images.githubusercontent.com/8375502/199868620-e8a8de0e-2697-406f-a837-b0e58d75f2e2.png)

Along with this change, I removed some unused union members from predicate builder types. The removed members were cruft from prototyping other predicate options.

The runtime error for `and` and `or` conditions was also un-instructive and a more instructive error has been made explicit.

**This PR will be redirected to `next-major-version/5` after #10610 is merged.**

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes

1. Added tests.
2. Built and verified intellisense in IDE. (See screenshots.)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
